### PR TITLE
Kubeconfig from secret

### DIFF
--- a/deployment/mcad-controller/templates/deployment.yaml
+++ b/deployment/mcad-controller/templates/deployment.yaml
@@ -310,10 +310,10 @@ spec:
       volumes:
       - name: temp-vol
         emptyDir: {}
-#{{ if .Values.volumes.hostPath }}
+#{{ if .Values.volumes.agentConfigSecret }}
       - name: agent-config-vol
         secret:
-          secretName: mcad-agents-config
+          secretName: {{ .Values.volumes.agentConfigSecret }}
 #{{ end }}
       containers:
 #{{ if .Values.configMap.quotaRestUrl }}

--- a/deployment/mcad-controller/templates/deployment.yaml
+++ b/deployment/mcad-controller/templates/deployment.yaml
@@ -312,8 +312,8 @@ spec:
         emptyDir: {}
 #{{ if .Values.volumes.hostPath }}
       - name: agent-config-vol
-        hostPath:
-          path: {{ .Values.volumes.hostPath }}
+        secret:
+          secretName: mcad-agents-config
 #{{ end }}
       containers:
 #{{ if .Values.configMap.quotaRestUrl }}

--- a/deployment/mcad-controller/values.yaml
+++ b/deployment/mcad-controller/values.yaml
@@ -56,6 +56,7 @@ configMap:
 
 volumes:
   hostPath:
+  agentConfigSecret: mcad-agents-config
 
 coscheduler:
   rbac:

--- a/deployment/mcad-controller/values.yaml
+++ b/deployment/mcad-controller/values.yaml
@@ -55,7 +55,6 @@ configMap:
   podCreationTimeout:
 
 volumes:
-  hostPath:
   agentConfigSecret: mcad-agents-config
 
 coscheduler:


### PR DESCRIPTION
Modified to use a secret to store agent kubeconfig files instead of using hostPath. Using a secret is a more general solution allowing to deploy mad dispatcher on remote clusters as well as locally in kind.