### PR TITLE
Parameterize namespace for deployment

### DIFF
--- a/deployment/mcad-controller/crds/ibm.com_quotasubtree-v1.yaml
+++ b/deployment/mcad-controller/crds/ibm.com_quotasubtree-v1.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: quotasubtrees.ibm.com
-  finalizers: []
 spec:
   group: ibm.com
   scope: Namespaced

--- a/deployment/mcad-controller/templates/configmap.yaml
+++ b/deployment/mcad-controller/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Values.configMap.name }}
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 data:
   QUOTA_ENABLED: {{ .Values.configMap.quotaEnabled }}
   DISPATCHER_MODE: {{ .Values.configMap.dispatcherMode }}

--- a/deployment/mcad-controller/templates/deployment.yaml
+++ b/deployment/mcad-controller/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: custom-metrics-apiserver
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 spec:
   ports:
   - name: https
@@ -40,7 +40,7 @@ metadata:
 spec:
   service:
     name: custom-metrics-apiserver
-    namespace: kube-system
+    namespace: {{ .Values.namespace }}
   group: external.metrics.k8s.io
   version: v1beta1
   insecureSkipTLSVerify: true
@@ -54,7 +54,7 @@ metadata:
 spec:
   service:
     name: custom-metrics-apiserver
-    namespace: kube-system
+    namespace: {{ .Values.namespace }}
   group: custom.metrics.k8s.io
   version: v1beta1
   insecureSkipTLSVerify: true
@@ -98,7 +98,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: horizontal-pod-autoscaler
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -185,7 +185,7 @@ metadata:
   labels:
     wdc.ibm.com/ownership: admin
   name: {{ .Values.serviceAccount }}
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 #{{ end }}
 ---
 #{{ if .Values.serviceAccount }}
@@ -200,13 +200,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount }}
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: custom-metrics-auth-reader
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -214,7 +214,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount }}
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -227,7 +227,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount }}
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -244,7 +244,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount }}
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -261,7 +261,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount }}
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -278,14 +278,14 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount }}
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 #{{ end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.deploymentName }}
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     app: custom-metrics-apiserver

--- a/deployment/mcad-controller/templates/imageSecret.yaml
+++ b/deployment/mcad-controller/templates/imageSecret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.imagePullSecret.name }}
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "imagePullSecret" . }}

--- a/deployment/mcad-controller/templates/mcad-agents-config.yaml
+++ b/deployment/mcad-controller/templates/mcad-agents-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+kind: Secret
+metadata:
+  name: mcad-agents-config
+  namespace: mcad
+type: Opaque

--- a/deployment/mcad-controller/values.yaml
+++ b/deployment/mcad-controller/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 deploymentName: mcad-controller
-namespace: kube-system
+namespace: mcad
 replicaCount: 1
 loglevel: 4
 

--- a/deployment/mcad-controller/values.yaml
+++ b/deployment/mcad-controller/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 deploymentName: mcad-controller
-namespace: mcad
+namespace: kube-system
 replicaCount: 1
 loglevel: 4
 


### PR DESCRIPTION
Parameterize namespace for mcad dispatcher and agent. Added empty secret to hold kubeconfig for every edge cluster 